### PR TITLE
Add the ability to consume the IconImage

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -640,6 +640,12 @@ impl IconImage {
     pub fn rgba_data(&self) -> &[u8] {
         &self.rgba_data
     }
+        
+    /// Consumes this `IconImage` and returns the raw RGBA data in row-major order
+    /// as an owned `Vec<u8>`
+    pub fn take_rgba_data(self) -> Vec<u8> {
+        self.rgba_data
+    }
 
     pub(crate) fn compute_stats(&self) -> ImageStats {
         let mut colors = BTreeSet::<(u8, u8, u8)>::new();

--- a/src/image.rs
+++ b/src/image.rs
@@ -643,7 +643,7 @@ impl IconImage {
         
     /// Consumes this `IconImage` and returns the raw RGBA data in row-major order
     /// as an owned `Vec<u8>`
-    pub fn take_rgba_data(self) -> Vec<u8> {
+    pub fn into_rgba_data(self) -> Vec<u8> {
         self.rgba_data
     }
 


### PR DESCRIPTION
This is useful for embedding an ico window icon and using it with `winit`, which requires that the icon is a `Vec<u8>`