### PR TITLE
Add optional serde support to IconDir

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 [dependencies]
 byteorder = "1"
 png = "0.17"
+serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
 clap = "2.30"

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -1,6 +1,8 @@
 use crate::image::{IconImage, ImageStats};
 use crate::restype::ResourceType;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
 use std::io::{self, Read, Seek, SeekFrom, Write};
 
 //===========================================================================//
@@ -11,7 +13,8 @@ const PNG_SIGNATURE: &[u8] = &[0x89, b'P', b'N', b'G'];
 //===========================================================================//
 
 /// A collection of images; the contents of a single ICO or CUR file.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct IconDir {
     restype: ResourceType,
     entries: Vec<IconDirEntry>,
@@ -169,7 +172,8 @@ impl IconDir {
 //===========================================================================//
 
 /// One entry in an ICO or CUR file; a single icon or cursor.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 pub struct IconDirEntry {
     restype: ResourceType,
     width: u32,

--- a/src/restype.rs
+++ b/src/restype.rs
@@ -1,6 +1,10 @@
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 //===========================================================================//
 
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Deserialize, Serialize))]
 /// The type of resource stored in an ICO/CUR file.
 pub enum ResourceType {
     /// Plain images (ICO files)


### PR DESCRIPTION
I want to be able serialize `IconDir`s into RON, so this commit adds support for that.

To be more concrete, I am decoding .ANI animated cursors and I want to be able to debug what is inside them. E.g. I want to be able to see icon dimensions and hotspot data:

<img width="324" alt="image" src="https://github.com/user-attachments/assets/9e47878e-c88c-47e2-8436-8ec9456f36bc" />

Many Rust crates offer optional serde support by a feature flag, e.g. https://github.com/bitshifter/glam-rs and https://github.com/indexmap-rs/indexmap. So hopefully this is a fine change.

Also add Debug derive to IconDir.