### PR TITLE
Fix OOM panic in IconDir::read by validating entry size (#12)

### DIFF
--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -93,7 +93,11 @@ impl IconDir {
             // Reject invalid ICO entries whose data range exceeds the actual file size.
             if data_offset as u64 + data_size as u64 > file_len {
                invalid_data!(
-                  "Image data span (offset={}, size={}) exceeds file length ({})",data_offset,data_size,file_len);
+                  "Image data span (offset={}, size={}) exceeds file length ({})",
+                   data_offset,
+                   data_size,
+                   file_len
+               );
             }
             // The ICONDIRENTRY struct uses only one byte each for width and
             // height.  In older versions of Windows, a byte of zero indicated

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -52,6 +52,11 @@ impl IconDir {
 
     /// Reads an ICO or CUR file into memory.
     pub fn read<R: Read + Seek>(mut reader: R) -> io::Result<IconDir> {
+
+        // Get total file length so we can validate size fields.
+        let file_len = reader.seek(SeekFrom::End(0))?;
+        reader.seek(SeekFrom::Start(0))?;
+        
         let reserved = reader.read_u16::<LittleEndian>()?;
         if reserved != 0 {
             invalid_data!(
@@ -84,6 +89,12 @@ impl IconDir {
             let bits_per_pixel = reader.read_u16::<LittleEndian>()?;
             let data_size = reader.read_u32::<LittleEndian>()?;
             let data_offset = reader.read_u32::<LittleEndian>()?;
+
+            // Reject invalid ICO entries whose data range exceeds the actual file size.
+            if data_offset as u64 + data_size as u64 > file_len {
+               invalid_data!(
+                  "Image data span (offset={}, size={}) exceeds file length ({})",data_offset,data_size,file_len);
+            }
             // The ICONDIRENTRY struct uses only one byte each for width and
             // height.  In older versions of Windows, a byte of zero indicated
             // a size of exactly 256, but since Windows Vista a byte of zero is

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -92,12 +92,12 @@ impl IconDir {
 
             // Reject invalid ICO entries whose data range exceeds the actual file size.
             if data_offset as u64 + data_size as u64 > file_len {
-               invalid_data!(
-                  "Image data span (offset={}, size={}) exceeds file length ({})",
-                   data_offset,
-                   data_size,
-                   file_len
-               );
+                invalid_data!(
+                    "Image data span (offset={}, size={}) exceeds file length ({})",
+                    data_offset,
+                    data_size,
+                    file_len
+                );
             }
             // The ICONDIRENTRY struct uses only one byte each for width and
             // height.  In older versions of Windows, a byte of zero indicated

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -52,7 +52,6 @@ impl IconDir {
 
     /// Reads an ICO or CUR file into memory.
     pub fn read<R: Read + Seek>(mut reader: R) -> io::Result<IconDir> {
-
         // Get total file length so we can validate size fields.
         let file_len = reader.seek(SeekFrom::End(0))?;
         reader.seek(SeekFrom::Start(0))?;

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -56,7 +56,6 @@ impl IconDir {
         // Get total file length so we can validate size fields.
         let file_len = reader.seek(SeekFrom::End(0))?;
         reader.seek(SeekFrom::Start(0))?;
-        
         let reserved = reader.read_u16::<LittleEndian>()?;
         if reserved != 0 {
             invalid_data!(

--- a/src/image.rs
+++ b/src/image.rs
@@ -323,7 +323,7 @@ impl IconImage {
             None => invalid_data!("Width * Height is too large"),
         };
 
-         //Check image size limits to prevent excessive memory allocation
+         // Check image size limits to prevent excessive memory allocation
         if num_pixels as u64 > MAX_PIXELS {
             invalid_data!(
                 "Image dimensions too large ({}x{} = {} pixels, max is {})",

--- a/src/image.rs
+++ b/src/image.rs
@@ -11,11 +11,11 @@ const BMP_HEADER_LEN: u32 = 40;
 // Size limits for images in an ICO file:
 const MIN_WIDTH: u32 = 1;
 const MIN_HEIGHT: u32 = 1;
-
+const MAX_PIXELS: u64 = 8192 * 8192;
 //===========================================================================//
 
 /// A decoded image.
-#[derive(Clone)]
+#[derive(克隆)]
 pub struct IconImage {
     width: u32,
     height: u32,
@@ -322,6 +322,12 @@ impl IconImage {
             Some(num) => num as usize,
             None => invalid_data!("Width * Height is too large"),
         };
+
+         //Check image size limits to prevent excessive memory allocation
+        if num_pixels as u64 > MAX_PIXELS {
+            invalid_data!(
+                "Image dimensions too large ({}x{} = {} pixels, max is {})",width,height,num_pixels,MAX_PIXELS);}
+
         let mut rgba = vec![u8::MAX; num_pixels * 4];
         let row_data_size = (width * (bits_per_pixel as u32)).div_ceil(8);
         let row_padding_size = row_data_size.div_ceil(4) * 4 - row_data_size;

--- a/src/image.rs
+++ b/src/image.rs
@@ -15,7 +15,7 @@ const MAX_PIXELS: u64 = 8192 * 8192;
 //===========================================================================//
 
 /// A decoded image.
-#[derive(克隆)]
+#[derive(Clone)]
 pub struct IconImage {
     width: u32,
     height: u32,

--- a/src/image.rs
+++ b/src/image.rs
@@ -326,7 +326,13 @@ impl IconImage {
          //Check image size limits to prevent excessive memory allocation
         if num_pixels as u64 > MAX_PIXELS {
             invalid_data!(
-                "Image dimensions too large ({}x{} = {} pixels, max is {})",width,height,num_pixels,MAX_PIXELS);}
+                "Image dimensions too large ({}x{} = {} pixels, max is {})",
+                width,
+                height,
+                num_pixels,
+                MAX_PIXELS
+            );
+        }
 
         let mut rgba = vec![u8::MAX; num_pixels * 4];
         let row_data_size = (width * (bits_per_pixel as u32)).div_ceil(8);

--- a/src/image.rs
+++ b/src/image.rs
@@ -323,7 +323,7 @@ impl IconImage {
             None => invalid_data!("Width * Height is too large"),
         };
 
-         // Check image size limits to prevent excessive memory allocation
+        // Check image size limits to prevent excessive memory allocation
         if num_pixels as u64 > MAX_PIXELS {
             invalid_data!(
                 "Image dimensions too large ({}x{} = {} pixels, max is {})",


### PR DESCRIPTION
This PR addresses the OOM panic reported in #12.

Changes:
- Added a check to validate that the entry size specified in the ICO directory does not exceed the actual file length.
- Returns an `InvalidData` error if the declared size is larger than the available data, preventing excessive memory allocation.

Fixes #12