### PR TITLE
Upgrade png dependency to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "1"
-png = "0.17"
+png = "0.18"
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/examples/icotool.rs
+++ b/examples/icotool.rs
@@ -59,6 +59,7 @@ fn main() {
             for path in paths {
                 println!("Adding {:?}", path);
                 let file = fs::File::open(path).unwrap();
+                let file = std::io::BufReader::new(file);
                 let image = ico::IconImage::read_png(file).unwrap();
                 icondir.add_entry(ico::IconDirEntry::encode(&image).unwrap());
             }

--- a/src/icondir.rs
+++ b/src/icondir.rs
@@ -250,7 +250,9 @@ impl IconDirEntry {
     /// Decodes just enough of the raw image data to determine its size.
     pub(crate) fn decode_size(&mut self) -> io::Result<(u32, u32)> {
         if self.is_png() {
-            let png_reader = IconImage::read_png_info(self.data.as_slice())?;
+            let png_reader = IconImage::read_png_info(io::Cursor::new(
+                self.data.as_slice(),
+            ))?;
             Ok((png_reader.info().width, png_reader.info().height))
         } else {
             IconImage::read_bmp_size(&mut self.data.as_slice())
@@ -261,7 +263,7 @@ impl IconDirEntry {
     /// malformed or can't be decoded.
     pub fn decode(&self) -> io::Result<IconImage> {
         let mut image = if self.is_png() {
-            IconImage::read_png(self.data.as_slice())?
+            IconImage::read_png(io::Cursor::new(self.data.as_slice()))?
         } else {
             IconImage::read_bmp(self.data.as_slice())?
         };

--- a/src/image.rs
+++ b/src/image.rs
@@ -1,7 +1,7 @@
 use crate::bmpdepth::BmpDepth;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::{BTreeSet, HashMap};
-use std::io::{self, Read, Write};
+use std::io::{self, BufRead, Read, Seek, Write};
 
 //===========================================================================//
 
@@ -84,7 +84,7 @@ impl IconImage {
         IconImage { width, height, hotspot: None, rgba_data }
     }
 
-    pub(crate) fn read_png_info<R: Read>(
+    pub(crate) fn read_png_info<R: BufRead + Seek>(
         reader: R,
     ) -> io::Result<png::Reader<R>> {
         let decoder = png::Decoder::new(reader);
@@ -120,9 +120,13 @@ impl IconImage {
 
     /// Decodes an image from a PNG file.  Returns an error if the PNG data is
     /// malformed or can't be decoded.
-    pub fn read_png<R: Read>(reader: R) -> io::Result<IconImage> {
+    pub fn read_png<R: BufRead + Seek>(reader: R) -> io::Result<IconImage> {
         let mut png_reader = IconImage::read_png_info(reader)?;
-        let mut buffer = vec![0u8; png_reader.output_buffer_size()];
+        let buffer_len = match png_reader.output_buffer_size() {
+            Some(l) => l,
+            None => invalid_data!("PNG data exceeds isize::MAX"),
+        };
+        let mut buffer = vec![0u8; buffer_len];
         match png_reader.next_frame(&mut buffer) {
             Ok(_) => {}
             Err(error) => invalid_data!("Malformed PNG data: {}", error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@
 //! let mut icon_dir = ico::IconDir::new(ico::ResourceType::Icon);
 //! // Read a PNG file from disk and add it to the collection:
 //! let file = std::fs::File::open("path/to/image.png").unwrap();
+//! let file = std::io::BufReader::new(file);
 //! let image = ico::IconImage::read_png(file).unwrap();
 //! icon_dir.add_entry(ico::IconDirEntry::encode(&image).unwrap());
 //! // Alternatively, you can create an IconImage from raw RGBA pixel data

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -44,6 +44,7 @@ fn compare_ico_and_png(ico_path: &str, ico_index: usize, png_path: &str) {
     );
     let ico_image = icon_dir.entries()[ico_index].decode().unwrap();
     let png_file = File::open(&png_path).unwrap();
+    let png_file = std::io::BufReader::new(png_file);
     let png_image = ico::IconImage::read_png(png_file).unwrap();
     assert_eq!(
         ico_image.width(),


### PR DESCRIPTION
Reasons for the upgrade:

* The `output_buffer_size` now check for address space overflow.
* The image crate uses this version so the dependency is unified for crates that depend on both ico and image.

Note that this is a **breaking change** because `IconImage::read_png`  input now needs to be `BufRead + Seek`.